### PR TITLE
Don't set empty bucket policy attribute

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,6 @@ resource "aws_s3_bucket" "site" {
 resource "aws_s3_bucket" "www" {
   bucket = "www.${var.site_domain}"
   acl    = "private"
-  policy = ""
 
   website {
     redirect_all_requests_to = "https://${var.site_domain}"


### PR DESCRIPTION
Setting the bucket policy as an attribute will be deprecated in AWS Provider 4.0. Also, no need to set an empty policy, so just removed it altogether.

Also see the corresponding change for the `page-rules` branch: #3 